### PR TITLE
fix public-docker-registry.yaml detect conditions

### DIFF
--- a/public-docker-registry.yaml
+++ b/public-docker-registry.yaml
@@ -9,8 +9,7 @@ generate:
     - replace
 detect:
   - response:
-    - headers:
-      - 'Content-Type': 'application\/json'
+    - body: '\{"repositories":\[.*\]'
 meta-info:
   - type: info
   - threat: 60


### PR DESCRIPTION
detecting content-type is not enough - added a regexp for checking content body