### PR TITLE
Added new dsl-detects

### DIFF
--- a/CORS-Header-Origin:Referer-Reflect.yaml
+++ b/CORS-Header-Origin:Referer-Reflect.yaml
@@ -1,0 +1,25 @@
+collect:
+  - uniq:
+    - [ URI ]
+generate:
+  - into: 
+    - HEADER_ORIGIN
+    - HEADER_REFERER
+  - payload:
+    - STR_MARKER
+  - method:
+    - postfix
+    - prefix
+    - replace
+detect:
+  - response:
+    - headers:
+      - 'Access-Control-Allow-Origin': 'STR_MARKER'
+    - body: 'STR_MARKER'
+meta-info:
+  - type: info
+  - threat: 30
+  - tags:
+    - CORS
+    - Cross-Origin Resource Sharing
+    - Header Origin/Referer Reflect

--- a/Insecure-cross-domain-policy.yaml
+++ b/Insecure-cross-domain-policy.yaml
@@ -10,12 +10,8 @@ generate:
     - replace
 detect:
   - response:
-    - body: '<allow-access-from domain="\*"'
-    - body: '<allow-access-from domain="http://\*"'
-    - body: '<allow-access-from domain="https://\*"'
-    - body: '<domain uri="\*"'
-    - body: '<domain uri="http://\*"'
-    - body: '<domain uri="https://\*"'
+    - body: '<allow-access-from domain=".*\*"'
+    - body: '<domain uri=".*\*"'
 meta-info:
   - type: info
   - threat: 25

--- a/Insecure-cross-domain-policy.yaml
+++ b/Insecure-cross-domain-policy.yaml
@@ -1,0 +1,26 @@
+collect:
+  - uniq:
+    - [ HEADER_HOST ]
+generate:
+  - into: URI
+  - payload:
+    - 'crossdomain.xml'
+    - 'clientaccesspolicy.xml'
+  - method:
+    - replace
+detect:
+  - response:
+    - body: '<allow-access-from domain="\*"'
+    - body: '<allow-access-from domain="http://\*"'
+    - body: '<allow-access-from domain="https://\*"'
+    - body: '<domain uri="\*"'
+    - body: '<domain uri="http://\*"'
+    - body: '<domain uri="https://\*"'
+meta-info:
+  - type: info
+  - threat: 25
+  - tags: 
+    - CORS
+    - Cross-origin resource sharing
+    - CWE-942
+    - Misconfiguration

--- a/Tango-REST-Misconfiguration.yaml
+++ b/Tango-REST-Misconfiguration.yaml
@@ -1,0 +1,20 @@
+collect:
+  - uniq:
+    - [ HEADER_HOST ]
+generate:
+  - into: URI
+  - payload:
+    - 'tango/console'
+    - 'tango/rest'
+  - method:
+    - replace
+detect:
+  - response:
+    - headers:
+      - 'WWW-Authenticate': 'Basic realm="TangoREST"'
+meta-info:
+  - type: info
+  - threat: 25
+  - tags: 
+    - TangoREST
+    - Misconfiguration

--- a/apache-tomcat-misconfiguration.yaml
+++ b/apache-tomcat-misconfiguration.yaml
@@ -11,10 +11,11 @@ generate:
     - replace
 detect:
   - response:
-    - body: '<title>401 Unauthorized<\/title>'
     - body: '<title>JSP Examples<\/title>'
     - body: '<title>JSP 2.0 Examples'
     - body: '<title>Apache Tomcat Examples<\/title>'
+  - headers:
+      - 'WWW-Authenticate': 'Basic realm="Tomcat Manager Application"'
 meta-info:
   - type: info
   - threat: 25

--- a/apache-tomcat-misconfiguration.yaml
+++ b/apache-tomcat-misconfiguration.yaml
@@ -1,0 +1,23 @@
+collect:
+  - uniq:
+    - [ HEADER_HOST ]
+generate:
+  - into: URI
+  - payload:
+    - 'manager/html/'
+    - 'examples/'
+    - 'examples/jsp/'
+  - method:
+    - replace
+detect:
+  - response:
+    - body: '<title>401 Unauthorized<\/title>'
+    - body: '<title>JSP Examples<\/title>'
+    - body: '<title>JSP 2.0 Examples'
+    - body: '<title>Apache Tomcat Examples<\/title>'
+meta-info:
+  - type: info
+  - threat: 25
+  - tags: 
+    - Apache Tomcat
+    - Misconfiguration

--- a/crlf.yaml
+++ b/crlf.yaml
@@ -1,0 +1,19 @@
+collect:
+  - uniq:
+    - [ URI ]
+generate:
+  - payload:
+    - "%0d%0ax-crlf-header: STR_MARKER"
+    - "%0ax-crlf-header: STR_MARKER"
+  - method:
+    - postfix
+detect:
+  - response:
+    - headers:
+      - 'x-crlf-header': 'STR_MARKER'
+meta-info:
+  - type: info
+  - threat: 30
+  - tags: 
+    - CRLF
+    - Injection

--- a/crlf.yaml
+++ b/crlf.yaml
@@ -12,7 +12,7 @@ detect:
     - headers:
       - 'x-crlf-header': 'STR_MARKER'
 meta-info:
-  - type: info
+  - type: crlf
   - threat: 30
   - tags: 
     - CRLF


### PR DESCRIPTION
Added new DSL-detects which include:
Tango REST Misconfiguration - it's a misconfiguration in tango REST server, which includes public access to critical administration functions with hard-coded credentials.
Apache Tomcat Misconfiguration - it's a misconfiguration in Apache Tomcat server, which includes public access to critical administrative functions.
Insecure cross-domain policy - misconfiguration in crossdomain.xml/clientaccesspolicy.xml files.
CRLF - is's a CRLF header injection.
Header origin/referer reflect - it detects misconfiguration in Access-Control-Allow-Origin.